### PR TITLE
fix mapping primitive repeating element 

### DIFF
--- a/fns-hl7-pipeline/fn-mmg-sql-transformer/src/main/kotlin/gov/cdc/dex/hl7/TransformerSql.kt
+++ b/fns-hl7-pipeline/fn-mmg-sql-transformer/src/main/kotlin/gov/cdc/dex/hl7/TransformerSql.kt
@@ -106,7 +106,7 @@ class TransformerSql {
                 elName to elModelArr.map { elMod ->
                     if (!profilesMap.containsKey(elDataType)) {
                         val elValue = elMod.asJsonPrimitive
-                        mapOf(elName to elValue)
+                        mapOf("$elName${SEPARATOR}value" to elValue)
                     } else {
                         val mmgDataType = el.mappings.hl7v251.dataType
                         val sqlPreferred = profilesMap[mmgDataType]!!.filter { it.preferred }

--- a/fns-hl7-pipeline/fn-mmg-sql-transformer/src/test/resources/modelTB.json
+++ b/fns-hl7-pipeline/fn-mmg-sql-transformer/src/test/resources/modelTB.json
@@ -474,7 +474,7 @@
 		"cdc_preferred_designation": "Yes"
 	},
 	"linked_case_number": [
-		"2018GA287163402"
+		"2018GA287163402", "2018GA123123456"
 	],
 	"date_treatment_or_therapy_started": "20180210",
 	"treatment_administration_type": [


### PR DESCRIPTION
Repeating element "linked_case_number" was not showing up in databricks because the sql transformer was mapping the value to the same name as the repeating table name (i.e., table name and column name were the same). This update adds "_value" to the column name so that it is different from the table name.