### PR TITLE
update legacy mmgs to not include subject/patient name type field

### DIFF
--- a/mrr/src/main/resources/legacy_mmgs/Arboviral_v1_3_2_MMG_20210721.json
+++ b/mrr/src/main/resources/legacy_mmgs/Arboviral_v1_3_2_MMG_20210721.json
@@ -155,45 +155,6 @@
       "shouldDisplayName": false,
       "elements": [
         {
-          "id": "75d291c8-684c-52e3-8ae1-7bd3c346b187",
-          "guideId": "2c48b64b-885e-5595-989d-b20f62ceb0c1",
-          "guideInternalVersion": 0,
-          "blockId": "2",
-          "ordinal": 1,
-          "name": "Patient name type",
-          "description": "Name is not requested by the program, but the Patient Name field is required to be populated for the HL7 message to be valid.  Have adopted the HL7 convention for processing a field where the name has been removed for de-identification purposes.",
-          "comments": "",
-          "status": "Final",
-          "dataType": "Coded",
-          "businessRules": "",
-          "isUnitOfMeasure": false,
-          "legacyCodeSystem": "PHINQUESTION",
-          "codeSystem": "PHINQUESTION",
-          "legacyPriority": "R",
-          "priority": 1,
-          "isRepeat": true,
-          "mayRepeat": "Y/2",
-          "valueSetCode": "PHVS_NameType_HL7_2x",
-          "mappings": {
-            "hl7v251": {
-              "legacyIdentifier": "DEM100",
-              "identifier": "DEM100",
-              "messageContext": "PID-5 Patient Name field",
-              "dataType": "XPN",
-              "segmentType": "PID",
-              "obrPosition": 1,
-              "fieldPosition": 5,
-              "componentPosition": 7,
-              "usage": "R",
-              "cardinality": "[1..2]",
-              "literalFieldValues": {},
-              "repeatingGroupElementType": "NO",
-              "implementationNotes": "Literal value:  |~^^^^^^S|\n\nSECOND INSTANCE - where PID-5.7 Patient Name Type - is S for Pseudonym.  HL7 reserves the first instance of the name for Legal Name.",
-              "sampleSegment": ""
-            }
-          }
-        },
-        {
           "id": "84a8112d-c27b-52ab-a244-0762ec25e95a",
           "guideId": "2c48b64b-885e-5595-989d-b20f62ceb0c1",
           "guideInternalVersion": 0,

--- a/mrr/src/main/resources/legacy_mmgs/VaricellaCaseNationalNotificationMap_v1_0.json
+++ b/mrr/src/main/resources/legacy_mmgs/VaricellaCaseNationalNotificationMap_v1_0.json
@@ -157,45 +157,6 @@
           }
         },
         {
-          "id": "815be666-d5a1-44f4-8ede-1eb0f2869612",
-          "guideId": "880e7fe9-c82e-4359-b70a-cd741338de49",
-          "guideInternalVersion": 0,
-          "blockId": "2",
-          "ordinal": 2,
-          "name": "Patient name type",
-          "description": "Name is not requested by the program, but the Patient Name field is required to be populated for the HL7 message to be valid. Have adopted the HL7 convention for processing a field where the name has been removed for de-identification purposes.",
-          "comments": "",
-          "status": "Final",
-          "dataType": "Coded",
-          "businessRules": "",
-          "isUnitOfMeasure": false,
-          "legacyCodeSystem": "PHINQUESTION",
-          "codeSystem": "PHINQUESTION",
-          "legacyPriority": "R",
-          "priority": 1,
-          "isRepeat": false,
-          "mayRepeat": "N",
-          "valueSetCode": "",
-          "mappings": {
-            "hl7v251": {
-              "legacyIdentifier": "DEM100",
-              "identifier": "DEM100",
-              "messageContext": "PID-5.7 Patient Name Type - second instance (does not pass Variable ID or label). HL7 reserves the first instance of the name for Legal Name.",
-              "dataType": "XPN",
-              "segmentType": "PID",
-              "obrPosition": 1,
-              "fieldPosition": 5,
-              "componentPosition": 7,
-              "usage": "R",
-              "cardinality": "[1..1]",
-              "literalFieldValues": {},
-              "repeatingGroupElementType": "NO",
-              "implementationNotes": "Literal value: |~^^^^^^S|",
-              "sampleSegment": ""
-            }
-          }
-        },
-        {
           "id": "97f14f04-0885-4f36-9650-9c54cefba2e8",
           "guideId": "880e7fe9-c82e-4359-b70a-cd741338de49",
           "guideInternalVersion": 0,

--- a/mrr/src/main/resources/legacy_mmgs/arboviral_human_case_message_mapping_guide.json
+++ b/mrr/src/main/resources/legacy_mmgs/arboviral_human_case_message_mapping_guide.json
@@ -194,45 +194,6 @@
           }
         },
         {
-          "id": "75d291c8-684c-52e3-8ae1-7bd3c346b187",
-          "guideId": "51592ac7-45c6-56e3-9417-0c698baa273f",
-          "guideInternalVersion": 0,
-          "blockId": "2",
-          "ordinal": 2,
-          "name": "Patient name type",
-          "description": "Name is not requested by the program, but the Patient Name field is required to be populated for the HL7 message to be valid.  Have adopted the HL7 convention for processing a field where the name has been removed for de-identification purposes.",
-          "comments": "",
-          "status": "Final",
-          "dataType": "Coded",
-          "businessRules": "",
-          "isUnitOfMeasure": false,
-          "legacyCodeSystem": "PHINQUESTION",
-          "codeSystem": "PHINQUESTION",
-          "legacyPriority": "R",
-          "priority": 1,
-          "isRepeat": true,
-          "mayRepeat": "Y/2",
-          "valueSetCode": "PHVS_NameType_HL7_2x",
-          "mappings": {
-            "hl7v251": {
-              "legacyIdentifier": "DEM100",
-              "identifier": "DEM100",
-              "messageContext": "PID-5 Patient Name field",
-              "dataType": "XPN",
-              "segmentType": "PID",
-              "obrPosition": 1,
-              "fieldPosition": 5,
-              "componentPosition": 7,
-              "usage": "R",
-              "cardinality": "[1..2]",
-              "literalFieldValues": {},
-              "repeatingGroupElementType": "NO",
-              "implementationNotes": "Literal value:  |~^^^^^^S|\n\nSECOND INSTANCE - where PID-5.7 Patient Name Type - is S for Pseudonym.  HL7 reserves the first instance of the name for Legal Name.",
-              "sampleSegment": ""
-            }
-          }
-        },
-        {
           "id": "887f63dd-2728-5841-ae1f-78d1bc86d9e9",
           "guideId": "51592ac7-45c6-56e3-9417-0c698baa273f",
           "guideInternalVersion": 0,

--- a/mrr/src/main/resources/legacy_mmgs/gen_case_map_v1.0.json
+++ b/mrr/src/main/resources/legacy_mmgs/gen_case_map_v1.0.json
@@ -194,45 +194,6 @@
           }
         },
         {
-          "id": "6d148514-7826-4831-a4d6-602a76ee4585",
-          "guideId": "1c89083d-8b2d-417e-bab7-84907d756a52",
-          "guideInternalVersion": 0,
-          "blockId": "2",
-          "ordinal": 2,
-          "name": "Subject Name Type",
-          "description": "Name is not requested by the program, but the Patient Name field is required to be populated for the HL7 message to be valid.  Have adopted the HL7 convention for processing a field where the name has been removed for de-identification purposes.",
-          "comments": "",
-          "status": "Final",
-          "dataType": "Coded",
-          "businessRules": "",
-          "isUnitOfMeasure": false,
-          "legacyCodeSystem": "PHINQUESTION",
-          "codeSystem": "PHINQUESTION",
-          "legacyPriority": "R",
-          "priority": 1,
-          "isRepeat": false,
-          "mayRepeat": "Y/2",
-          "valueSetCode": "PHVS_NameType_HL7_2x",
-          "mappings": {
-            "hl7v251": {
-              "legacyIdentifier": "DEM100",
-              "identifier": "DEM100",
-              "messageContext": "PID-5.7-Patient Name Type",
-              "dataType": "XPN",
-              "segmentType": "PID",
-              "obrPosition": 0,
-              "fieldPosition": 5,
-              "componentPosition": 7,
-              "usage": "R",
-              "cardinality": "[1..2]",
-              "literalFieldValues": {},
-              "repeatingGroupElementType": "NO",
-              "implementationNotes": "Literal value:  |~^^^^^^S|\n\nPatient Name Type is passed in the second instance as HL7 reserves the first instance of the name field for Legal Name.",
-              "sampleSegment": ""
-            }
-          }
-        },
-        {
           "id": "2a19dbe4-0207-45e4-a0cc-af3d188417ea",
           "guideId": "1c89083d-8b2d-417e-bab7-84907d756a52",
           "guideInternalVersion": 0,

--- a/mrr/src/main/resources/legacy_mmgs/summ_case_map_v1.0.json
+++ b/mrr/src/main/resources/legacy_mmgs/summ_case_map_v1.0.json
@@ -193,45 +193,7 @@
             }
           }
         },
-        {
-          "id": "d31fb775-95bb-4c54-a9d3-4723bc5e8527",
-          "guideId": "67edc608-2a89-41e5-8725-538a7880d82d",
-          "guideInternalVersion": 0,
-          "blockId": "2",
-          "ordinal": 2,
-          "name": "Subject Name Type",
-          "description": "Name is not requested by the program, but the Patient Name field is required to be populated for the HL7 message to be valid.  Have adopted the HL7 convention for processing a field where the name has been removed for de-identification purposes.",
-          "comments": "",
-          "status": "Final",
-          "dataType": "Coded",
-          "businessRules": "",
-          "isUnitOfMeasure": false,
-          "legacyCodeSystem": "PHINQUESTION",
-          "codeSystem": "PHINQUESTION",
-          "legacyPriority": "R",
-          "priority": 1,
-          "isRepeat": false,
-          "mayRepeat": "Y/2",
-          "valueSetCode": "PHVS_NameType_HL7_2x",
-          "mappings": {
-            "hl7v251": {
-              "legacyIdentifier": "DEM100",
-              "identifier": "DEM100",
-              "messageContext": "PID-5.7-Patient Name Type",
-              "dataType": "XPN",
-              "segmentType": "PID",
-              "obrPosition": 0,
-              "fieldPosition": 5,
-              "componentPosition": 7,
-              "usage": "R",
-              "cardinality": "[1..2]",
-              "literalFieldValues": {},
-              "repeatingGroupElementType": "NO",
-              "implementationNotes": "Literal value:  |~^^^^^^S|\n\nPatient Name Type is passed in the second instance as HL7 reserves the first instance of the name field for Legal Name.",
-              "sampleSegment": ""
-            }
-          }
-        }
+
       ]
     },
     {

--- a/mrr/src/main/resources/legacy_mmgs/tuberculosis_message_mapping_guide_v2_03.json
+++ b/mrr/src/main/resources/legacy_mmgs/tuberculosis_message_mapping_guide_v2_03.json
@@ -194,45 +194,6 @@
           }
         },
         {
-          "id": "9bca691d-6412-4fad-889e-1ebac5d8987f",
-          "guideId": "1c364ab9-d6a2-46e4-9437-9dc57b8b313e",
-          "guideInternalVersion": 0,
-          "blockId": "2",
-          "ordinal": 2,
-          "name": "Subject Name Type",
-          "description": "Name is not requested by the program, but the Patient Name field is required to be populated for the HL7 message to be valid.  Have adopted the HL7 convention for processing a field where the name has been removed for de-identification purposes.",
-          "comments": "",
-          "status": "Final",
-          "dataType": "Coded",
-          "businessRules": "",
-          "isUnitOfMeasure": false,
-          "legacyCodeSystem": "PHINQUESTION",
-          "codeSystem": "PHINQUESTION",
-          "legacyPriority": "R",
-          "priority": 1,
-          "isRepeat": true,
-          "mayRepeat": "Y/2",
-          "valueSetCode": "PHVS_NameType_HL7_2x",
-          "mappings": {
-            "hl7v251": {
-              "legacyIdentifier": "DEM100",
-              "identifier": "DEM100",
-              "messageContext": "PID-5.7-Patient Name Type",
-              "dataType": "XPN",
-              "segmentType": "PID",
-              "obrPosition": 1,
-              "fieldPosition": 5,
-              "componentPosition": 7,
-              "usage": "R",
-              "cardinality": "[1..2]",
-              "literalFieldValues": {},
-              "repeatingGroupElementType": "NO",
-              "implementationNotes": "Literal value:  |~^^^^^^S|\n\nPatient Name Type is passed in the second instance as HL7 reserves the first instance of the name field for Legal Name.",
-              "sampleSegment": ""
-            }
-          }
-        },
-        {
           "id": "ee6381a3-39bd-458c-a72a-6c1bd4f61b56",
           "guideId": "1c364ab9-d6a2-46e4-9437-9dc57b8b313e",
           "guideInternalVersion": 0,

--- a/mrr/src/main/resources/legacy_mmgs/varicella_message_mapping_guide_v2_01.json
+++ b/mrr/src/main/resources/legacy_mmgs/varicella_message_mapping_guide_v2_01.json
@@ -194,45 +194,6 @@
           }
         },
         {
-          "id": "05813b24-30b2-46e7-9e69-a0481c58de97",
-          "guideId": "2489c217-fa74-4ec5-b626-920be20777b1",
-          "guideInternalVersion": 0,
-          "blockId": "2",
-          "ordinal": 2,
-          "name": "Subject Name Type",
-          "description": "Name is not requested by the program, but the Patient Name field is required to be populated for the HL7 message to be valid.  Have adopted the HL7 convention for processing a field where the name has been removed for de-identification purposes.",
-          "comments": "",
-          "status": "Final",
-          "dataType": "Coded",
-          "businessRules": "",
-          "isUnitOfMeasure": false,
-          "legacyCodeSystem": "PHINQUESTION",
-          "codeSystem": "PHINQUESTION",
-          "legacyPriority": "R",
-          "priority": 1,
-          "isRepeat": true,
-          "mayRepeat": "Y/2",
-          "valueSetCode": "PHVS_NameType_HL7_2x",
-          "mappings": {
-            "hl7v251": {
-              "legacyIdentifier": "DEM100",
-              "identifier": "DEM100",
-              "messageContext": "PID-5.7-Patient Name Type",
-              "dataType": "XPN",
-              "segmentType": "PID",
-              "obrPosition": 1,
-              "fieldPosition": 5,
-              "componentPosition": 7,
-              "usage": "R",
-              "cardinality": "[1..2]",
-              "literalFieldValues": {},
-              "repeatingGroupElementType": "NO",
-              "implementationNotes": "Literal value:  |~^^^^^^S|\n\nPatient Name Type is passed in the second instance as HL7 reserves the first instance of the name field for Legal Name.",
-              "sampleSegment": ""
-            }
-          }
-        },
-        {
           "id": "360dfb1f-6fad-4a22-a3bf-037c1345218b",
           "guideId": "2489c217-fa74-4ec5-b626-920be20777b1",
           "guideInternalVersion": 0,


### PR DESCRIPTION
The field PID-5.7 is included in these mmgs and is resulting in unnecessary sql-gold tables.  This update removes the field PID-5.7 "subject name type" or "patient name type".