### PR TITLE
Remove hard-coded container name

### DIFF
--- a/fns-hl7-pipeline/fn-receiver-debatcher/src/main/kotlin/gov/cdc/dex/hl7/receiver/Function.kt
+++ b/fns-hl7-pipeline/fn-receiver-debatcher/src/main/kotlin/gov/cdc/dex/hl7/receiver/Function.kt
@@ -64,7 +64,7 @@ class Function {
                 if ( event.eventType == BLOB_CREATED) {
 
                     // Pick up blob metadata
-                    val blobName= event.evHubData.url.substringAfter("/${fnConfig.azureBlobContainer}/")
+                    val blobName= event.evHubData.url.substringAfter("/${fnConfig.blobIngestContName}/")
                     context.logger.info("DEX::Reading blob: $blobName")
                     val blobClient = fnConfig.azBlobProxy.getBlobClient(blobName)
                     //Create Map of Metadata with lower case keys

--- a/fns-hl7-pipeline/fn-receiver-debatcher/src/main/kotlin/gov/cdc/dex/hl7/receiver/Function.kt
+++ b/fns-hl7-pipeline/fn-receiver-debatcher/src/main/kotlin/gov/cdc/dex/hl7/receiver/Function.kt
@@ -64,7 +64,7 @@ class Function {
                 if ( event.eventType == BLOB_CREATED) {
 
                     // Pick up blob metadata
-                    val blobName= event.evHubData.url.substringAfter("/hl7ingress/")
+                    val blobName= event.evHubData.url.substringAfter("/${fnConfig.azureBlobContainer}/")
                     context.logger.info("DEX::Reading blob: $blobName")
                     val blobClient = fnConfig.azBlobProxy.getBlobClient(blobName)
                     //Create Map of Metadata with lower case keys

--- a/fns-hl7-pipeline/fn-receiver-debatcher/src/main/kotlin/gov/cdc/dex/hl7/receiver/FunctionConfig.kt
+++ b/fns-hl7-pipeline/fn-receiver-debatcher/src/main/kotlin/gov/cdc/dex/hl7/receiver/FunctionConfig.kt
@@ -13,7 +13,7 @@ class FunctionConfig {
 
     val evHubOkName: String = System.getenv("EventHubSendOkName")
     val evHubErrorName: String = System.getenv("EventHubSendErrsName")
-
+    val azureBlobContainer: String = System.getenv("AZURE_BLOB_CONTAINER") ?: "hl7ingress"
     init {
          //Init Event Hub connections
          val evHubConnStr = System.getenv("EventHubConnectionString")

--- a/fns-hl7-pipeline/fn-receiver-debatcher/src/main/kotlin/gov/cdc/dex/hl7/receiver/FunctionConfig.kt
+++ b/fns-hl7-pipeline/fn-receiver-debatcher/src/main/kotlin/gov/cdc/dex/hl7/receiver/FunctionConfig.kt
@@ -13,7 +13,7 @@ class FunctionConfig {
 
     val evHubOkName: String = System.getenv("EventHubSendOkName")
     val evHubErrorName: String = System.getenv("EventHubSendErrsName")
-    val azureBlobContainer: String = System.getenv("AZURE_BLOB_CONTAINER") ?: "hl7ingress"
+    val blobIngestContName = System.getenv("BlobIngestContainerName")
     init {
          //Init Event Hub connections
          val evHubConnStr = System.getenv("EventHubConnectionString")
@@ -26,7 +26,6 @@ class FunctionConfig {
          mmgUtil = MmgUtil(redisProxy)
 
          //Init Azure Storage connection
-         val blobIngestContName = System.getenv("BlobIngestContainerName")
          val ingestBlobConnStr = System.getenv("BlobIngestConnectionString")
          azBlobProxy = AzureBlobProxy(ingestBlobConnStr, blobIngestContName)
     }


### PR DESCRIPTION
In Receiver-Debatcher: Made BlobIngestContainerName accessible from FunctionConfig and replaced hard-coded reference in Function with variable reference. This makes it possible to actually switch storage containers :)