### PR TITLE
use environment variables to properly set credentials

### DIFF
--- a/local_libs/lib-dex-commons/build.gradle.kts
+++ b/local_libs/lib-dex-commons/build.gradle.kts
@@ -61,11 +61,10 @@ publishing {
             val snapshotsRepoUrl = "https://imagehub.cdc.gov/repository/maven-ede-snapshot/"
             url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl)
             name = "nexus"
-            credentials(PasswordCredentials::class)// {
-            //Add this to ~/.gradle/gradle.properties
-//                username="$nexusUsername"
-//                password="$nexusPassword"
-//            }
+            credentials(PasswordCredentials::class) {
+                username = System.getenv("NEXUS_USERNAME")
+                password = System.getenv("NEXUS_PASSWORD")
+            }
         }
     }
 }


### PR DESCRIPTION
To minimize exposure of sensitive information, handle credentials securely in `build.gradle` file.