### PR TITLE
#HL7-2196 Fix OBR size error in Unit test

### DIFF
--- a/local_libs/lib-bumblebee/src/test/groovy/gov/cdc/hl7/bumblebee/TemplateTransformerSpec.groovy
+++ b/local_libs/lib-bumblebee/src/test/groovy/gov/cdc/hl7/bumblebee/TemplateTransformerSpec.groovy
@@ -38,9 +38,10 @@ class TemplateTransformerSpec extends Specification {
           print(newMessage)
         then:
             def jsonSlurper = new JsonSlurper()
-            def object = jsonSlurper.parseText(newMessage)
+            def obj = jsonSlurper.parseText(newMessage)
 
-            assert object instanceof Map
+            assert obj instanceof Map
+            def object = (Map)obj
             assert object.specimen_id == '214MP000912'
             assert object.message_profile == "PHLabReport-NoAck"
             assert object.message_controller_id == "ARLN_GC_DupASTmOBR_ELR"
@@ -50,7 +51,7 @@ class TemplateTransformerSpec extends Specification {
             assert object.message_status == "F"
             assert object.race[0] == "Native Hawaiian"
             assert object.race[1] == "White"
-            assert object.OBR.size ==7
+            assert object.OBR.size() == 7
             assert object.OBR[1].Group == "33"
             assert object.OBR[1].type == "SN"
             assert object.OBR[1].question.code == "35659-2"


### PR DESCRIPTION
change .size property reference to .size() method call in TemplateTransformerSpec.groovy