### PR TITLE
HL7-2265-correct typo in nist validator CI trigger name

### DIFF
--- a/.github/workflows/hl7-remote-cicd.yml
+++ b/.github/workflows/hl7-remote-cicd.yml
@@ -192,7 +192,7 @@ jobs:
               *lib-bumblebee*) workflows+=("ci-lib-bumblebee.yml") ;;&
               *lib-cloud-proxy*) workflows+=("ci-lib-cloud-proxy.yml") ;;&
               *lib-dex-commons*) workflows+=("ci-lib-dex-commons.yml") ;;&
-              *lib-nist-validator*) workflows+=("ci-iib-nist-validator.yml") ;;&   
+              *lib-nist-validator*) workflows+=("ci-lib-nist-validator.yml") ;;&   
               *) ;;
               esac
             fi


### PR DESCRIPTION
correct typo in nist validator CI trigger name