### PR TITLE
Hl7 2335 strucvalid elr deprecate

### DIFF
--- a/fns-hl7-pipeline/fn-structure-validator/src/main/kotlin/gov/cdc/dex/validation/structure/ValidatorFunction.kt
+++ b/fns-hl7-pipeline/fn-structure-validator/src/main/kotlin/gov/cdc/dex/validation/structure/ValidatorFunction.kt
@@ -153,7 +153,7 @@ class ValidatorFunction {
                 HL7MessageType.CASE -> HL7StaticParser.getFirstValue(hl7Content, PHIN_SPEC_PROFILE).get()
                     .uppercase(Locale.getDefault())
                 HL7MessageType.ELR -> "${route.uppercase()}-v${HL7StaticParser.getFirstValue(hl7Content, ELR_SPEC_PROFILE).get().uppercase()}"
-                else -> throw InvalidMessageException("Invalid Message Type: $messageType. Please specify CASE")
+                else -> throw InvalidMessageException("Invalid Message Type: $messageType. Please specify CASE or ELR")
             }
         return profileName
     }

--- a/fns-hl7-pipeline/fn-structure-validator/src/main/kotlin/gov/cdc/dex/validation/structure/ValidatorFunction.kt
+++ b/fns-hl7-pipeline/fn-structure-validator/src/main/kotlin/gov/cdc/dex/validation/structure/ValidatorFunction.kt
@@ -27,7 +27,7 @@ import java.util.*
 class ValidatorFunction {
     companion object {
         private const val PHIN_SPEC_PROFILE = "MSH-21[1].1" //Not able to use HL7-PET due to scala version conflicts with NistValidator.
-        private const val ELR_SPEC_PROFILE = "MSH-12"
+        // private const val ELR_SPEC_PROFILE = "MSH-12"
         const val PROCESS_STATUS_OK = "SUCCESS"
         const val PROCESS_STATUS_EXCEPTION = "FAILURE"
         private const val NIST_VALID_MESSAGE = "VALID_MESSAGE"
@@ -62,7 +62,7 @@ class ValidatorFunction {
         val evHubNameOk = getSafeEnvVariable("EventHubSendOkName")
         val evHubNameErrs = getSafeEnvVariable("EventHubSendErrsName")
         val evHubConnStr = getSafeEnvVariable("EventHubConnectionString")
-        val evHubNameELROk = getSafeEnvVariable("EventHubSendELROkName")
+        // val evHubNameELROk = getSafeEnvVariable("EventHubSendELROkName")
 
         val ehSender = EventHubSender(evHubConnStr)
 
@@ -104,7 +104,7 @@ class ValidatorFunction {
                 inputEvent.add("summary", JsonParser.parseString(gson.toJson(summary)))
 
                 //Send event
-                val ehDestination = getEhDestination(messageType, report, evHubNameOk, evHubNameELROk, evHubNameErrs)
+                val ehDestination = getEhDestination(report, evHubNameOk, evHubNameErrs)
                 //val ehDestination = if (NIST_VALID_MESSAGE == report.status) evHubNameOk else evHubNameErrs
                 val destIndicator = if (ehDestination == evHubNameErrs) {
                     "ERROR"
@@ -136,15 +136,11 @@ class ValidatorFunction {
     }
 
     private fun getEhDestination(
-        messageType: String,
         report: NistReport,
         evHubNameOk: String,
-        evHubNameELROk: String,
         evHubNameErrs: String
     ): String {
-        return if (messageType == "ELR" && NIST_VALID_MESSAGE == report.status) {
-            evHubNameELROk
-        } else if (messageType == "CASE" && NIST_VALID_MESSAGE == report.status) {
+        return if (NIST_VALID_MESSAGE == report.status) {
             evHubNameOk
         } else {
             evHubNameErrs
@@ -156,8 +152,8 @@ class ValidatorFunction {
             when (messageType) {
                 HL7MessageType.CASE -> HL7StaticParser.getFirstValue(hl7Content, PHIN_SPEC_PROFILE).get()
                     .uppercase(Locale.getDefault())
-                HL7MessageType.ELR -> "${route.uppercase()}-v${HL7StaticParser.getFirstValue(hl7Content, ELR_SPEC_PROFILE).get().uppercase()}"
-                else -> throw InvalidMessageException("Invalid Message Type: $messageType. Please specify CASE or ELR")
+                // HL7MessageType.ELR -> "${route.uppercase()}-v${HL7StaticParser.getFirstValue(hl7Content, ELR_SPEC_PROFILE).get().uppercase()}"
+                else -> throw InvalidMessageException("Invalid Message Type: $messageType. Please specify CASE")
             }
         return profileName
     }
@@ -232,7 +228,7 @@ class ValidatorFunction {
         val messageType = if (!request.headers["x-tp-message_type"].isNullOrEmpty()) {
             request.headers["x-tp-message_type"].toString()
         } else {
-            return buildHttpResponse("BAD REQUEST: Message Type ('CASE' or 'ELR') " +
+            return buildHttpResponse("BAD REQUEST: Message Type ('CASE') " +
                     "must be specified in the HTTP Header as 'x-tp-message_type'. " +
                     "Please correct the HTTP header and try again.",
                 HttpStatus.BAD_REQUEST,
@@ -241,15 +237,7 @@ class ValidatorFunction {
         val route = if (!request.headers["x-tp-route"].isNullOrEmpty()) {
             request.headers["x-tp-route"].toString()
         } else {
-            if (messageType == "ELR") {
-                return buildHttpResponse("BAD REQUEST: ELR message must specify a route" +
-                        " in the HTTP header as 'x-tp-route'. " +
-                        "Please correct the HTTP header and try again.",
-                HttpStatus.BAD_REQUEST,
-                request)
-            } else {
-                ""
-            }
+           ""
         }
 
         return try {

--- a/fns-hl7-pipeline/fn-structure-validator/src/test/kotlin/gov/cdc/dex/ValidationTest.kt
+++ b/fns-hl7-pipeline/fn-structure-validator/src/test/kotlin/gov/cdc/dex/ValidationTest.kt
@@ -40,9 +40,7 @@ class ValidationTest {
     @Test
     fun testELRMessage() {
         val testMessage = this::class.java.getResource("/covidELR/2.3.1 HL7 Test File with HHS Data.txt")?.readText()
-
         val nistValidator = ProfileManager(ResourceFileFetcher(), "/COVID19_ELR-v2.3.1")
-
         val report = nistValidator.validate(testMessage!!)
         println("report: -->\n\n${gson.toJson(report)}\n")
         //


### PR DESCRIPTION
Updated to spit outcome into a single Event Hub Topic. 

Main change was in the `getEhDestination()` function. 