### PR TITLE
update kotlin version

### DIFF
--- a/local_libs/lib-nist-validator/build.gradle.kts
+++ b/local_libs/lib-nist-validator/build.gradle.kts
@@ -5,6 +5,7 @@
 plugins {
     `java-library`
     `maven-publish`
+    kotlin("jvm") version "1.9.0"
 }
 
 repositories {
@@ -16,6 +17,8 @@ repositories {
     maven {
         url = uri("https://repo.maven.apache.org/maven2/")
     }
+    mavenCentral()
+    gradlePluginPortal()
 }
 
 dependencies {
@@ -23,10 +26,10 @@ dependencies {
     api("gov.nist:hl7-v2-profile:1.6.3")
     api("gov.nist:hl7-v2-validation:1.6.3")
     api("com.google.code.gson:gson:2.10.1")
-    api("org.jetbrains.kotlin:kotlin-stdlib:1.7.20")
+    api("org.jetbrains.kotlin:kotlin-stdlib:1.9.0")
     api("org.junit.jupiter:junit-jupiter-engine:5.9.0")
     api("org.slf4j:slf4j-api:2.0.5")
-    testImplementation("org.jetbrains.kotlin:kotlin-test:1.7.20")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.9.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.0")
 }
@@ -34,7 +37,7 @@ dependencies {
 group = "gov.cdc.dex"
 version = "1.3.5-SNAPSHOT"
 description = "lib-nist-validator"
-java.sourceCompatibility = JavaVersion.VERSION_1_8
+java.sourceCompatibility = JavaVersion.VERSION_11
 
 publishing {
     publications.create<MavenPublication>("maven") {

--- a/local_libs/lib-nist-validator/src/test/java/gov/cdc/nist/validator/ProfileManagerTest.java
+++ b/local_libs/lib-nist-validator/src/test/java/gov/cdc/nist/validator/ProfileManagerTest.java
@@ -16,7 +16,7 @@ public class ProfileManagerTest {
     @Test
     public void testValidateStructureErrors() {
         try {
-            ProfileManager nistValidator = new ProfileManager(new ResourceFileFetcher(), "/TEST_PROF");
+            var nistValidator = new ProfileManager(new ResourceFileFetcher(), "/TEST_PROF");
 
             var nist = nistValidator.validate(getTestFile("hl7TestMessage.txt"));
             System.out.println("nist.getStatus() = " + nist.getStatus());


### PR DESCRIPTION
update kotlin version because version 1.7.20 is broken. Updating the kotlin version fixed the tests. 1.7.20 seems to be broke where is says the version cannot be resolved. All dependencies of 1.7.20 including the testing library will throw errors. This has happened in past versions.

https://youtrack.jetbrains.com/issue/KT-53209
https://youtrack.jetbrains.com/issue/KT-47477/Could-not-resolve-kotlin-test-during-project-import-in-case-of-multiplatform-with-only-JVM-target-platform