### PR TITLE
update for dynamic metadata

### DIFF
--- a/fns-hl7-pipeline/fn-receiver-debatcher/pom.xml
+++ b/fns-hl7-pipeline/fn-receiver-debatcher/pom.xml
@@ -36,7 +36,7 @@
         <gson.version>2.10.1</gson.version>
 
         <hl7pet.version>1.2.7.1</hl7pet.version>
-        <lib-dex-commons.version>1.0.18-SNAPSHOT</lib-dex-commons.version>
+        <lib-dex-commons.version>1.0.19-SNAPSHOT</lib-dex-commons.version>
         <junitjupiter.version>5.9.2</junitjupiter.version>
 
     </properties>


### PR DESCRIPTION
metadata.provenance.source_metadata accommodates dynamic metadata.
null when no dynamic meta present
![source_meta](https://github.com/CDCgov/data-exchange-hl7/assets/133129579/90e2cc4e-f72c-4e1d-bdc3-2a0d9b59e5e1)
data absent