### PR TITLE
Structure Validator load profiles on demand #HL7-2495

### DIFF
--- a/fns-hl7-pipeline/fn-structure-validator/src/main/kotlin/gov/cdc/dex/hl7/Function.kt
+++ b/fns-hl7-pipeline/fn-structure-validator/src/main/kotlin/gov/cdc/dex/hl7/Function.kt
@@ -193,7 +193,7 @@ class ValidatorFunction {
             throw InvalidMessageException("Unable to process message: Unable to retrieve PHIN Specification from $PHIN_SPEC_PROFILE$exMessage")
         }
 
-        val nistValidator = fnConfig.nistValidators[profileName]
+        val nistValidator = fnConfig.getNistValidator(profileName)
         if (nistValidator == null) {
             throw InvalidMessageException("Unsupported route $profileName")
         } else {


### PR DESCRIPTION
Instead of loading all profiles up front, load each one on demand (once) and keep it in a MutableMap for future use