### PR TITLE
HL7-2519: Create OpenAPI documentation for the Replay API functionality

### DIFF
--- a/svc-hl7-replay/openapi.properties
+++ b/svc-hl7-replay/openapi.properties
@@ -1,0 +1,1 @@
+swagger-ui.enabled=true

--- a/svc-hl7-replay/pom.xml
+++ b/svc-hl7-replay/pom.xml
@@ -137,6 +137,11 @@
             <artifactId>lib-dex-commons</artifactId>
             <version>${lib-dex-commons.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>2.2.16</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -200,6 +205,16 @@
                                     <groupId>io.micronaut</groupId>
                                     <artifactId>micronaut-validation</artifactId>
                                     <version>${micronaut.version}</version>
+                                </annotationProcessorPath>
+                                <annotationProcessorPath>
+                                    <groupId>io.micronaut</groupId>
+                                    <artifactId>micronaut-validation</artifactId>
+                                    <version>${micronaut.version}</version>
+                                </annotationProcessorPath>
+                                <annotationProcessorPath>
+                                    <groupId>io.micronaut.openapi</groupId>
+                                    <artifactId>micronaut-openapi</artifactId>
+                                    <version>4.8.4</version>
                                 </annotationProcessorPath>
                           </annotationProcessorPaths>
                        </configuration>
@@ -318,7 +333,7 @@
                             <resource>
                                 <directory>${project.basedir}/target</directory>
                                 <includes>
-                                    <include>*.jar</include>
+                                    <include>${project.artifactId}-${project.version}.jar</include>
                                 </includes>
                             </resource>
                         </resources>

--- a/svc-hl7-replay/src/main/kotlin/gov/cdc/dex/replay/service/Application.kt
+++ b/svc-hl7-replay/src/main/kotlin/gov/cdc/dex/replay/service/Application.kt
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.info.Info
     info = Info(
         title = "HL7v2 Replay API",
         version = "1.0",
-        description = "An API for replaying processed HL7v2 messages both validated and errored to HL7V2 Pipeline")
+        description = "An API for replaying validated and error queued HL7v2 messages back to the HL7V2 Pipeline")
 )
 object Application {
 

--- a/svc-hl7-replay/src/main/kotlin/gov/cdc/dex/replay/service/Application.kt
+++ b/svc-hl7-replay/src/main/kotlin/gov/cdc/dex/replay/service/Application.kt
@@ -1,7 +1,14 @@
 package gov.cdc.dex.replay.service
 
 import io.micronaut.runtime.Micronaut
-
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.Info
+@OpenAPIDefinition(
+    info = Info(
+        title = "HL7v2 Replay API",
+        version = "1.0",
+        description = "An API for replaying processed HL7v2 messages both validated and errored to HL7V2 Pipeline")
+)
 object Application {
 
     @JvmStatic
@@ -13,4 +20,5 @@ object Application {
             .start()
     }
 }
+
 

--- a/svc-hl7-replay/src/main/kotlin/gov/cdc/dex/replay/service/ReplayController.kt
+++ b/svc-hl7-replay/src/main/kotlin/gov/cdc/dex/replay/service/ReplayController.kt
@@ -1,24 +1,21 @@
 package gov.cdc.dex.replay.service
 
+import gov.cdc.dex.azure.EventHubSender
+
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpHeaders
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Post
-import gov.cdc.dex.azure.EventHubMetadata
-import gov.cdc.dex.azure.EventHubSender
-import gov.cdc.dex.metadata.*
+import io.micronaut.http.MediaType
+
 import org.slf4j.LoggerFactory
 import java.util.*
-import java.time.Instant
 
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
-
-import io.micronaut.http.HttpRequest
-import io.micronaut.http.MediaType
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -30,12 +27,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 
-
-/**
- *
- * @Created - 8/15/23
- * @Author UUX3@cdc.gov
- */
 
 data class UniqueData(
     val id: String,
@@ -58,26 +49,27 @@ data class ReplayMD(
 ) {
     constructor() : this(null, null, null, null)
 }
-enum class MessageQueryType(
-    start_date:Date, end_date:Date, jurisdiction: String, route: String
-)
-@Schema(description = "Request Object for Replay by messages and files")
+enum class MessageQueryType{
+    start_date,
+    end_date,
+    jurisdiction,
+    route
+}
+@Schema(description = "Request Object for Replay by file uuid")
 data class RequestReplay(
     @Schema(description = "Reason for replay",example = "Message is error queued", required = true)
     val reason: String,
-    @Schema(description = "User", required = true)
+    @Schema(description = "User calling the API", required = true)
     val user: String,
-    @Schema(description = "Start Date ",example = "Message is error queued")
+    @Schema(description = "Start Date of file to be replayed",example = "")
     val start_date: Date?,
-    @Schema(description = "End Date ",example = "Message is error queued")
+    @Schema(description = "End Date of file to be replayed",example = "2023-10-12T16:02:37.481Z")
     val end_date: Date?,
-    @Schema(description = "Message query method ",example = "start_date", required = true)
-    val message_query: MessageQueryType,
+    @Schema(description = "Message query method ",example = "2023-10-14T16:02:37.481Z", required = true)
+    val message_query: MessageQueryType
 )
 @Controller("/replay")
-// @Requires(property = "micronaut.security.enabled", value = "false")
 class ReplayController {
-
     companion object {
         val gson: Gson = GsonBuilder().serializeNulls().create()
         val evHubConnStr: String = System.getenv("EventHubConnectionString")
@@ -86,19 +78,18 @@ class ReplayController {
     @Post("/{message_uuid}", consumes=[MediaType.APPLICATION_JSON], produces =[MediaType.APPLICATION_JSON])
     @Operation(summary = "Replays HL7 Message both validated and error queued by message UUID")
     @Parameters(
-        Parameter(name="message_uuid", `in` = ParameterIn.PATH, description =" Replays validated or error queued HL7 messages by message uuid", required=true, schema=Schema(type = "string"), example = "123e4567-e89b-12d3-a456-426655440000")
+        Parameter(name="message_uuid", `in` = ParameterIn.PATH, description =" Replays HL7 messages by message uuid", required=true, schema=Schema(type = "string"), example = "123e4567-e89b-12d3-a456-426655440000")
     )
     @ApiResponses(
-        ApiResponse(content = [Content(mediaType = MediaType.APPLICATION_JSON, schema = Schema(type = "string"))]),
         ApiResponse(responseCode = "200", description = "Success"),
         ApiResponse(responseCode =  "400", description = "Bad request"),
-        ApiResponse(responseCode =  "404", description = "Resource not found"),
+        ApiResponse(responseCode =  "403", description = "Authorization Error"),
         ApiResponse(responseCode =  "500", description = "Internal error")
     )
     fun replayMessageUUIDController(
 
         @RequestBody(
-            description = " Request Object for replaying messages by message uuid",
+            description = "Request Object for replaying message by message uuid",
             content = [Content(schema = Schema(implementation = RequestReplay::class))]
         )request: RequestReplay ):HttpResponse<String>{
 
@@ -109,13 +100,13 @@ class ReplayController {
     @Post("/{file_uuid}", consumes=[MediaType.APPLICATION_JSON], produces =[MediaType.APPLICATION_JSON])
     @Operation(summary = "Replays HL7 Message both validated and error queued by file UUID")
     @Parameters(
-        Parameter(name="file_uuid", `in` = ParameterIn.PATH, description =" Replays validated or error queued HL7 messages by file uuid", required=true, schema=Schema(type = "string"),example = "123e4567-e89b-12d3-a456-426655440000")
+        Parameter(name="file_uuid", `in` = ParameterIn.PATH, description =" Replays HL7 messages by file uuid", required=true, schema=Schema(type = "string"),example = "123e4567-e89b-12d3-a456-426655440000")
     )
     @ApiResponses(
         ApiResponse(content = [Content(mediaType = MediaType.APPLICATION_JSON, schema = Schema(type = "string"))]),
         ApiResponse(responseCode = "200", description = "Success"),
         ApiResponse(responseCode =  "400", description = "Bad request"),
-        ApiResponse(responseCode =  "404", description = "Resource not found"),
+        ApiResponse(responseCode =  "403", description = "Authorization Error"),
         ApiResponse(responseCode =  "500", description = "Internal error")
     )
     fun replayFileUUIDController(@RequestBody(
@@ -127,9 +118,6 @@ class ReplayController {
 
         return HttpResponse.ok()
     }
-
-
-
 
     fun handleMessage(@Body messageRequest: UniqueData, headers: HttpHeaders): HttpResponse<String> {
         val location = headers["location"]
@@ -148,64 +136,12 @@ class ReplayController {
         return HttpResponse.ok("Received message id: ${messageRequest.id}")
     }
 
-    @Post("/files")
-    fun handleFile(@Body messageRequest: UniqueData, headers: HttpHeaders): HttpResponse<String> {
-        val location = headers["location"]
-        println("Handling file: ${messageRequest.id} at location: $location")
-        // Build and Query DB
-        val query = returnQueryId("file_uuid", "Test", messageRequest.id)
-        // TODO - Run Query
-        // Create replay md
-        val replayMD = cleanReplayMetadata(null, query, messageRequest.reason, messageRequest.route)
-        // Build Message
-        // buildEventMD()
-
-        // Send Event Hub Message
-        val evResult = prepareAndSend( gson.toJson(replayMD), messageRequest.route)
-
-        return HttpResponse.ok("Received file id: ${messageRequest.id}")
-    }
-
-    @Post("/combo")
-    fun handleComboMessage(@Body comboData: CombinationData, headers: HttpHeaders): HttpResponse<String> {
-        val location = headers["location"]
-        println("Handling combo message: $comboData at location: $location")
-        // Build and Query DB
-        val query = queryCombo(comboData, "Test")
-        // TODO - Run Query
-        // Create replay md
-        val replayMD = cleanReplayMetadata(comboData, query)
-        // Build Message
-        // buildEventMD()
-
-        // Send Event Hub Message
-        val evResult = prepareAndSend( gson.toJson(replayMD), comboData.route)
-
-        return HttpResponse.ok("Received combination data: $comboData")
-    }
-
     // Supporting Fns - Query Builder
     private fun returnQueryId(identifier : String, table : String, id : String ): String {
         // Query based on Original Message with ID
         val query = "SELECT * FROM $table WHERE $identifier = $id"
         // TODO - Only original message, Replay MD should be null
         return query
-    }
-    private fun queryCombo(comboData: CombinationData?, table : String ) : String {
-        var conditionals = mutableListOf<String>()
-
-        // Double check columns in CosmosDB
-        comboData?.startDate?.let { conditionals.add("startdate='${comboData.startDate}'")}
-        comboData?.endDate?.let { conditionals.add("enddate='${comboData.endDate}'")}
-        comboData?.jurisdiction?.let { conditionals.add("jurisdiction='${comboData.jurisdiction}'")}
-
-        if (conditionals.isEmpty()){
-            // No Query values, alert user to provide values
-            return "ERROR"
-        }
-
-        val action = conditionals.joinToString { " AND " }
-        return "SELECT * FROM $table WHERE $action"
     }
     // Supporting Fns - Replay Metadata
     private fun cleanReplayMetadata(comboData: CombinationData?, queryFilter: String, reasonMsg: String = "", routeMsg: String = "" ) : ReplayMD {
@@ -252,7 +188,6 @@ class ReplayController {
         val eventHubSender = EventHubSender(evHubConnStr)
 
         eventHubSender.send(evHubTopicName=eventHubName, message=jsonMessage)
-        //println(msgEvent)
         return jsonMessage
     }
 }

--- a/svc-hl7-replay/src/main/resources/application.yml
+++ b/svc-hl7-replay/src/main/resources/application.yml
@@ -11,7 +11,14 @@ micronaut:
         enabled: true
         step: PT1M
         descriptions: true
-
+  router:
+    static-resources:
+      swagger:
+        paths: classpath:META-INF/swagger
+        mapping: /swagger/**
+      swagger-ui:
+        paths: classpath:META-INF/swagger/views/swagger-ui
+        mapping: /swagger-ui/**
 endpoints:
   all:
     enabled: false
@@ -23,6 +30,7 @@ endpoints:
   health:
     enabled: true
     details-visible: ANONYMOUS
+
 # ---------------------------------------------------------------------------------------------
 # To keep from setting these values here (and thus making it cloud agnostic), you'll need
 # to provide equivalent OS envvars in your project to configure. For example:


### PR DESCRIPTION
added replay/{file_uuid} replay/{message_uuid} POST including parameters
and APi responses with  different HTTP status codes
Created data class for Request Object for replay with different filtering options
added openapi.properties for Open API definition
updated pom with dependancies for swagger
changed deployment section of the pom file for azure-webapp-maven-plugin

corrected enum type class (MessageQueryType) to correctly detect enumtype for message_query
removed 404 HTTP Status Code and added 403, and 500
removed existing endpoints that are no longer needed
updated description for the Replay API
restructured imported libraries and removed unused ones.