### PR TITLE
Receiver-Debatcher update Azure BOM to 1.2.18 to fix eventhub send errors

### DIFF
--- a/fns-hl7-pipeline/fn-receiver-debatcher/pom.xml
+++ b/fns-hl7-pipeline/fn-receiver-debatcher/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <functionAppName>ocio-ede-${environment-id}-hl7-receiver-debatcher</functionAppName>
-        <AzureBom.version>1.2.15</AzureBom.version>
+        <AzureBom.version>1.2.18</AzureBom.version>
         <java.version>17</java.version>
         <kotlin.version>1.9.0</kotlin.version>
         <azure.functions.maven.plugin.version>1.26.0</azure.functions.maven.plugin.version>


### PR DESCRIPTION
 update Azure BOM to 1.2.18 to fix eventhub send errors