### PR TITLE
Lake of Segments update Azure BOM to 1.2.18 to fix eventhub send errors

### DIFF
--- a/fns-hl7-pipeline/fn-lake-segs-transformer/pom.xml
+++ b/fns-hl7-pipeline/fn-lake-segs-transformer/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <AzureBom.version>1.2.15</AzureBom.version>
+        <AzureBom.version>1.2.18</AzureBom.version>
         <java.version>17</java.version>
         <kotlin.version>1.9.0</kotlin.version>
         <functions.version>3.0.0</functions.version>


### PR DESCRIPTION
 update Azure BOM to 1.2.18 to fix eventhub send errors