### PR TITLE
#HL7-2773 Update Validator documentation to include DAART

### DIFF
--- a/svc-hl7-validation/README.md
+++ b/svc-hl7-validation/README.md
@@ -128,7 +128,7 @@ To submit successfully, callers must supply the message type as a query paramete
 "CASE" messages conform to a Message Mapping Guide (MMG) and PHIN Specification, while "ELR" messages conform to a 
 specification that constrains the HL7 ELR Implementation Guide for a specific condition or set of conditions tracked by 
 the CDC. When the message type is "ELR", the condition-related guide indicator must also be supplied, using the 
-query parameter "route". Valid values for "route" include "COVID19_ELR", "PHLIP_FLU", and "PHLIP_VPD".
+query parameter "route". Valid values for "route" include "COVID19_ELR", "PHLIP_FLU", "PHLIP_VPD", and "DAART".
 
 For the message body, an HL7 message or batch can be submitted as "raw" plain text, or a file containing the message
 or message batch can be uploaded as a binary attachment.

--- a/svc-hl7-validation/pom.xml
+++ b/svc-hl7-validation/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>gov.cdc.dex</groupId>
     <artifactId>svc-hl7-validation</artifactId>
-    <version>0.0.31-SNAPSHOT</version>
+    <version>0.0.37-SNAPSHOT</version>
     <!-- -->
     <parent>
         <groupId>io.micronaut</groupId>
@@ -23,7 +23,7 @@
         <kotlinVersion>1.9.0</kotlinVersion>
         <hl7pet.version>1.2.7.2</hl7pet.version>
         <gson.version>2.10.1</gson.version>
-        <lib-dex-commons.version>1.0.20-SNAPSHOT</lib-dex-commons.version>
+        <lib-dex-commons.version>1.0.24-SNAPSHOT</lib-dex-commons.version>
         <junitjupiter.version>5.9.2</junitjupiter.version>
     </properties>
 
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>gov.cdc.dex</groupId>
             <artifactId>lib-cloud-proxy</artifactId>
-            <version>0.0.29-SNAPSHOT</version>
+            <version>0.0.30-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>io.micronaut</groupId>
             <artifactId>micronaut-management</artifactId>
-            <version>3.8.5</version>
+            <version>3.8.7</version>
         </dependency>
 
         <dependency>

--- a/svc-hl7-validation/src/main/kotlin/gov/cdc/dex/validation/service/ValidationController.kt
+++ b/svc-hl7-validation/src/main/kotlin/gov/cdc/dex/validation/service/ValidationController.kt
@@ -191,7 +191,7 @@ Batch submissions are expected to include messages that are all the same message
                 schema = Schema(allowableValues = ["ELR", "CASE"], required = true, type = "string"),
                 description = "The type of data represented in the HL7 message.")
                 @QueryValue message_type: String,
-            @Parameter(name="route", schema = Schema(allowableValues = ["COVID19_ELR", "PHLIP_FLU", "PHLIP_VPD"], type = "string"),
+            @Parameter(name="route", schema = Schema(allowableValues = ["COVID19_ELR", "PHLIP_FLU", "PHLIP_VPD", "DAART"], type = "string"),
                 description = "Required for ELR only: the profile/specification name.")
                 @QueryValue route:Optional<String>,
             @RequestBody(content = [Content(mediaType = "text/plain", schema = Schema(type = "string") , examples = [


### PR DESCRIPTION
update README and swagger docs to include DAART; 
update lib-dex-commons version to 1.0.24-snapshot;
update lib-cloud-proxy version to 0.0.30-snapshot; 
update micronaut-management version to 3.8.7;
bump version to 0.0.37-snapshot