### PR TITLE
Update PhinGuideProfile_v2.json

### DIFF
--- a/fns-hl7-pipeline/fn-hl7-json-lake/src/main/resources/PhinGuideProfile_v2.json
+++ b/fns-hl7-pipeline/fn-hl7-json-lake/src/main/resources/PhinGuideProfile_v2.json
@@ -66,7 +66,7 @@
     "MSH":  [
       {
         "fieldNumber": 1,
-        "name": "File Separator",
+        "name": "Field Separator",
         "dataType": "ST",
         "maxLength": "1",
         "usage": "R",


### PR DESCRIPTION
fixing MSH-1 name to Field Separator (instead of file)