### PR TITLE
fixing msh-1 from file_separator to field_separator

### DIFF
--- a/local_libs/lib-bumblebee/src/main/kotlin/gov/cdc/hl7/bumblebee/HL7JsonTransformer.kt
+++ b/local_libs/lib-bumblebee/src/main/kotlin/gov/cdc/hl7/bumblebee/HL7JsonTransformer.kt
@@ -37,7 +37,7 @@ class HL7JsonTransformer(val profile: Profile, val fieldProfile: Profile, val hl
         }
         //Fix MSH-1 and 2:
         val msh =fullHL7.get("MSH").asJsonObject
-        msh.addProperty("file_separator", "|")
+        msh.addProperty("field_separator", "|")
         msh.addProperty("encoding_characters", "^~\\&")
         return fullHL7
 


### PR DESCRIPTION
MSH-1 and 2 are hardcoded. Need to fix the attribute name at the code level.