### PR TITLE
lib-dex-commons: upgrade azure-messaging-eventhubs library version

### DIFF
--- a/local_libs/lib-dex-commons/build.gradle.kts
+++ b/local_libs/lib-dex-commons/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "gov.cdc.dex"
-version = "0.0.37-SNAPSHOT"
+version = "0.0.38-SNAPSHOT"
 
 repositories {
     maven {
@@ -21,7 +21,7 @@ dependencies {
     testImplementation(kotlin("test"))
     implementation("com.google.code.gson:gson:2.10.1")
     //Azure:
-    implementation("com.azure:azure-messaging-eventhubs:5.15.4")
+    implementation("com.azure:azure-messaging-eventhubs:5.18.0")
     implementation("redis.clients:jedis:4.3.1")
     implementation("com.azure:azure-cosmos:4.51.0")
     testImplementation("org.mockito:mockito-core:5.6.0")


### PR DESCRIPTION
upgrade azure-messaging-eventhubs library version to match latest azure bom