### PR TITLE
#HL7-2844 Update json-lake 'report' to 'output'

### DIFF
--- a/fns-hl7-pipeline/fn-hl7-json-lake/src/main/kotlin/gov/cdc/dex/hl7/Function.kt
+++ b/fns-hl7-pipeline/fn-hl7-json-lake/src/main/kotlin/gov/cdc/dex/hl7/Function.kt
@@ -117,7 +117,7 @@ class Function {
         outData: MutableList<String>
     ): JsonObject {
 
-        val processMD = HL7JSONLakeProcessMetadata(status = status, report = report, eventHubMD = eventHubMD, config)
+        val processMD = HL7JSONLakeProcessMetadata(status = status, output = report, eventHubMD = eventHubMD, config)
         processMD.startProcessTime = startTime
         processMD.endProcessTime = Date().toIsoString()
         metadata.addArrayElement("processes", processMD)

--- a/fns-hl7-pipeline/fn-hl7-json-lake/src/main/kotlin/gov/cdc/dex/hl7/FunctionConfig.kt
+++ b/fns-hl7-pipeline/fn-hl7-json-lake/src/main/kotlin/gov/cdc/dex/hl7/FunctionConfig.kt
@@ -1,7 +1,6 @@
 package gov.cdc.dex.hl7
 
 import gov.cdc.dex.azure.DedicatedEventHubSender
-import gov.cdc.dex.azure.EventHubSender
 
 class FunctionConfig {
     companion object {

--- a/fns-hl7-pipeline/fn-hl7-json-lake/src/main/kotlin/gov/cdc/dex/hl7/HL7JSONLakeProcessMetadata.kt
+++ b/fns-hl7-pipeline/fn-hl7-json-lake/src/main/kotlin/gov/cdc/dex/hl7/HL7JSONLakeProcessMetadata.kt
@@ -4,7 +4,7 @@ import com.google.gson.JsonObject
 import gov.cdc.dex.azure.EventHubMetadata
 import gov.cdc.dex.metadata.ProcessMetadata
 
-data class HL7JSONLakeProcessMetadata(override val status: String, val report: JsonObject?, @Transient val eventHubMD: EventHubMetadata, @Transient val config: List<String>) //
+data class HL7JSONLakeProcessMetadata(override val status: String, val output: JsonObject?, @Transient val eventHubMD: EventHubMetadata, @Transient val config: List<String>) //
     : ProcessMetadata(PROCESS_NAME, PROCESS_VERSION,status,eventHubMD,config) {
 
     companion object  {


### PR DESCRIPTION
 update json-lake process metadata to save transformed data to 'output' node instead of 'report' node