### PR TITLE
#HL7-2845 Update lake of segments 'report' to 'output'

### DIFF
--- a/fns-hl7-pipeline/fn-lake-segs-transformer/src/main/kotlin/gov/cdc/dex/hl7/Function.kt
+++ b/fns-hl7-pipeline/fn-lake-segs-transformer/src/main/kotlin/gov/cdc/dex/hl7/Function.kt
@@ -125,7 +125,7 @@ class Function {
 
     private fun updateMetadata(startTime: String, status: String, report: List<Segment>?, eventHubMD: EventHubMetadata, inputEvent: JsonObject, exception: Exception?, config: List<String>): JsonObject {
 
-        val processMD = LakeSegsTransProcessMetadata(status=status, report=report, eventHubMD = eventHubMD, config)
+        val processMD = LakeSegsTransProcessMetadata(status=status, output=report, eventHubMD = eventHubMD, config)
         processMD.startProcessTime = startTime
         processMD.endProcessTime = Date().toIsoString()
 

--- a/fns-hl7-pipeline/fn-lake-segs-transformer/src/main/kotlin/gov/cdc/dex/hl7/LakeSegsTransProcessMetadata.kt
+++ b/fns-hl7-pipeline/fn-lake-segs-transformer/src/main/kotlin/gov/cdc/dex/hl7/LakeSegsTransProcessMetadata.kt
@@ -5,7 +5,7 @@ import gov.cdc.dex.metadata.ProcessMetadata
 
 import gov.cdc.dex.hl7.model.Segment
 
-data class LakeSegsTransProcessMetadata (override val status: String,  val report: List<Segment>?,@Transient val eventHubMD: EventHubMetadata, @Transient val config : List<String>) //
+data class LakeSegsTransProcessMetadata (override val status: String, val output: List<Segment>?, @Transient val eventHubMD: EventHubMetadata, @Transient val config : List<String>) //
     : ProcessMetadata(PROCESS_NAME, PROCESS_VERSION,status,eventHubMD,config) {
 
         companion object  {


### PR DESCRIPTION
update process metadata to use 'output' node instead of 'report' node for transformed data