### PR TITLE
Json-Lake-Transformer: Handle Messages Too Large for Event Hub

### DIFF
--- a/fns-hl7-pipeline/fn-hl7-json-lake/src/main/kotlin/gov/cdc/dex/hl7/Function.kt
+++ b/fns-hl7-pipeline/fn-hl7-json-lake/src/main/kotlin/gov/cdc/dex/hl7/Function.kt
@@ -7,7 +7,6 @@ import gov.cdc.dex.azure.EventHubMetadata
 import gov.cdc.dex.metadata.Problem
 import gov.cdc.dex.metadata.SummaryInfo
 import gov.cdc.dex.util.DateHelper.toIsoString
-import gov.cdc.dex.util.EventSizeExceededException
 import gov.cdc.dex.util.JsonHelper
 import gov.cdc.dex.util.JsonHelper.toJsonElement
 import gov.cdc.hl7.bumblebee.HL7JsonTransformer


### PR DESCRIPTION
update json lake transformer to handle list<int> returned from DedicatedEventHubSender