### PR TITLE
File-sink sidecar: make retry timeout, attempts, delay time configurable

### DIFF
--- a/fns-sidecars/hl7-file-sink/src/main/kotlin/gov/cdc/dataexchange/Function.kt
+++ b/fns-sidecars/hl7-file-sink/src/main/kotlin/gov/cdc/dataexchange/Function.kt
@@ -135,9 +135,10 @@ class Function {
             .setContentLanguage("en-US")
             .setContentType("binary")
 
-        var timeToWait = 0L
+        var timeToWait = fnConfig.bloblUploadRetryDelay.toLong()
+        val timeout = fnConfig.blobUploadTimeout.toLong()
         var mustRetry: Boolean
-        var retries = 3
+        var retries = fnConfig.blobUploadMaxRetries.toInt()
         do {
             if (retries < 3) logger.info("RETRYING upload of blob $blobName")
             mustRetry = try {
@@ -145,7 +146,7 @@ class Function {
                 val dataStream = data.toStream()
                 val response = client.uploadWithResponse(
                     dataStream, length, headers, newMetadata, AccessTier.HOT, md5,
-                    null, Duration.ofSeconds(2), null
+                    null, Duration.ofSeconds(timeout), null
                 )
                 (response.statusCode !in listOf(200, 201))
             } catch (ex: NativeIoException) {

--- a/fns-sidecars/hl7-file-sink/src/main/kotlin/gov/cdc/dataexchange/FunctionConfig.kt
+++ b/fns-sidecars/hl7-file-sink/src/main/kotlin/gov/cdc/dataexchange/FunctionConfig.kt
@@ -8,6 +8,10 @@ class FunctionConfig {
     var azureBlobProxy: AzureBlobProxy
     val blobStorageFolderName: String
     val blobStorageConnectionString: String
+    val blobUploadTimeout: String
+    val bloblUploadRetryDelay: String
+    val blobUploadMaxRetries: String
+
     private var logger = LoggerFactory.getLogger(FunctionConfig::class.java.simpleName)
 
     init {
@@ -33,5 +37,8 @@ class FunctionConfig {
             exitProcess(1)
         }
 
+        blobUploadTimeout = System.getenv("BlobUploadTimeoutSeconds") ?: "60"
+        bloblUploadRetryDelay = System.getenv("BlobUploadRetryDelaySeconds") ?: "10"
+        blobUploadMaxRetries = System.getenv("BlobUploadMaxRetries") ?: "3"
     }
 }


### PR DESCRIPTION
Add configuration environment variables for retry attempts, delay seconds, and timeout