### PR TITLE
#HL7-2877 lib-dex-commons add timeout to event hub health check

### DIFF
--- a/local_libs/lib-dex-commons/src/main/kotlin/gov/cdc/dex/azure/health/DependencyChecker.kt
+++ b/local_libs/lib-dex-commons/src/main/kotlin/gov/cdc/dex/azure/health/DependencyChecker.kt
@@ -1,5 +1,6 @@
 package gov.cdc.dex.azure.health
 
+import com.azure.core.amqp.AmqpRetryMode
 import com.azure.core.amqp.AmqpRetryOptions
 import com.azure.cosmos.CosmosClient
 import com.azure.cosmos.CosmosClientBuilder
@@ -38,6 +39,7 @@ class DependencyChecker {
     fun checkEventHub(connectionString: String, eventHubName: String) : DependencyHealthData {
         val retryOptions = AmqpRetryOptions()
             .setMaxRetries(1)
+            .setMode(AmqpRetryMode.FIXED)
             .setTryTimeout(Duration.ofSeconds(10))
 
         return checkDependency(AzureDependency.EVENT_HUB) {


### PR DESCRIPTION
limit retries to 1 and set a smaller timeout than default on event hub health check