### PR TITLE
#HL7-3074 Enhance File-Sink Sidecar health checks

### DIFF
--- a/fns-sidecars/hl7-file-sink/deployZip.sh
+++ b/fns-sidecars/hl7-file-sink/deployZip.sh
@@ -15,6 +15,7 @@ base_name=az-fun-$function_rootname.zip
 
 echo "Building Jar..."
 mvn clean package -DskipTests=true -Paz-$env
+rm base_name
 
 echo "Zipping it:"
 

--- a/fns-sidecars/hl7-file-sink/pom.xml
+++ b/fns-sidecars/hl7-file-sink/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>gov.cdc.dataexchange</groupId>
     <artifactId>hl7-file-sink</artifactId>
-    <version>0.0.45-SNAPSHOT</version>
+    <version>0.0.48-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Azure Kotlin Function :: hl7-file-sink</name>
     <scm>
@@ -24,7 +24,7 @@
         <functions.version>3.0.0</functions.version>
         <kotlin.version>1.9.0</kotlin.version>
         <hl7pet.version>1.2.7.2</hl7pet.version>
-        <lib-dex-commons.version>0.0.49-SNAPSHOT</lib-dex-commons.version>
+        <lib-dex-commons.version>0.0.51-SNAPSHOT</lib-dex-commons.version>
         <gson.version>2.10.1</gson.version>
     </properties>
 
@@ -111,7 +111,6 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-messaging-eventhubs</artifactId>
-            <version>5.16.0</version>
         </dependency>
 
         <dependency>
@@ -127,7 +126,6 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>12.23.0</version>
         </dependency>
     </dependencies>
 

--- a/fns-sidecars/hl7-file-sink/src/main/kotlin/gov/cdc/dataexchange/HealthCheckFunction.kt
+++ b/fns-sidecars/hl7-file-sink/src/main/kotlin/gov/cdc/dataexchange/HealthCheckFunction.kt
@@ -2,7 +2,11 @@ package gov.cdc.dataexchange
 
 import com.microsoft.azure.functions.*
 import com.microsoft.azure.functions.annotation.*
+import gov.cdc.dex.azure.health.DependencyChecker
+import gov.cdc.dex.azure.health.DependencyHealthData
+import gov.cdc.dex.azure.health.HealthCheckResult
 import java.util.*
+import kotlin.time.measureTime
 
 class HealthCheckFunction {
     @FunctionName("health")
@@ -14,10 +18,27 @@ class HealthCheckFunction {
             )
             request: HttpRequestMessage<Optional<String>>
     ): HttpResponseMessage {
+        val result = HealthCheckResult()
+        val evHubConnStr = System.getenv("EventHubConnectionString")
+        val evHubReceiveName = System.getenv("EventHubReceiveName")
+        val checker = DependencyChecker()
+        val time = measureTime {
+            addToResult(checker.checkEventHub(evHubConnStr, evHubReceiveName), result)
+            addToResult(checker.checkStorageAccount(
+                Function.fnConfig.blobStorageConnectionString,
+                Function.fnConfig.blobStorageContainerName), result)
+        }
+        result.totalChecksDuration = time.toComponents { hours, minutes, seconds, nanoseconds ->
+            "%02d:%02d:%02d.%03d".format(hours, minutes, seconds, nanoseconds / 1000000)
+        }
         return request
-                .createResponseBuilder(HttpStatus.OK)
-                .header("Content-Type", "application/json")
-                .body("UP")
-                .build();
+            .createResponseBuilder(HttpStatus.OK)
+            .header("Content-Type", "application/json")
+            .body(result)
+            .build()
+    }
+    private fun addToResult(dependencyData: DependencyHealthData, result: HealthCheckResult) {
+        result.dependencyHealthChecks.add(dependencyData)
+        if (dependencyData.status != "UP") result.status = "DOWNGRADED"
     }
 }

--- a/fns-sidecars/hl7-file-sink/src/main/kotlin/gov/cdc/dataexchange/HealthCheckFunction.kt
+++ b/fns-sidecars/hl7-file-sink/src/main/kotlin/gov/cdc/dataexchange/HealthCheckFunction.kt
@@ -19,12 +19,13 @@ class HealthCheckFunction {
             request: HttpRequestMessage<Optional<String>>
     ): HttpResponseMessage {
         val result = HealthCheckResult()
-        val evHubConnStr = System.getenv("EventHubConnectionString")
         val evHubReceiveName = System.getenv("EventHubReceiveName")
-        val checker = DependencyChecker()
+        val evHubConnStr = System.getenv("EventHubConnectionString")
+
+        val dependencyChecker = DependencyChecker()
         val time = measureTime {
-            addToResult(checker.checkEventHub(evHubConnStr, evHubReceiveName), result)
-            addToResult(checker.checkStorageAccount(
+            addToResult(dependencyChecker.checkEventHub(evHubConnStr, evHubReceiveName), result)
+            addToResult(dependencyChecker.checkStorageAccount(
                 Function.fnConfig.blobStorageConnectionString,
                 Function.fnConfig.blobStorageContainerName), result)
         }


### PR DESCRIPTION
add event hub and storage account checks to health check, 
remove versions from azure-messaging and azure-eventhubs in pom to force use of BOM version