### PR TITLE
Json-Lake: fix typos in PhinGuideProfile_v2

### DIFF
--- a/fns-hl7-pipeline/fn-hl7-json-lake/src/main/resources/PhinGuideProfile_v2.json
+++ b/fns-hl7-pipeline/fn-hl7-json-lake/src/main/resources/PhinGuideProfile_v2.json
@@ -643,7 +643,7 @@
       },
       {
         "fieldNumber": 4,
-        "name": "Place Group Number",
+        "name": "Placer Group Number",
         "dataType": "EI",
         "usage": "O",
         "cardinality": "[0..1]",
@@ -934,7 +934,7 @@
       },
       {
         "fieldNumber": 2,
-        "name": "Place Order Number",
+        "name": "Placer Order Number",
         "dataType": "EI",
         "maxLength": "427",
         "usage": "RE",


### PR DESCRIPTION
A couple of elements had "place" instead of "placer"